### PR TITLE
Added travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: python
+sudo: required
+
+# PyDetector need both Python versions installed to work
+before_install:
+    - sudo apt-get update 
+    - sudo apt-get install -y python2.7
+cache:
+  directories:
+    - $HOME/.cache/pip
+python:
+  - "3.6"
+install:
+  - pip2 install --upgrade pip
+  - pip3 install --upgrade pip
+  - pip3 install --upgrade .
+  - pip3 install --upgrade .
+  - pip2 install -r requirements.txt
+  - pip3 install -r requirements.txt
+script:
+  - python -m unittest discover tests/
+notifications:
+  email: false


### PR DESCRIPTION
The kludgy `apt-get install` and the doubled `pip install` commands for every Python version is because PyDetector needs both versions of Python (2.x and 3.x) installed but Travis [doesn't seem to support multiple languages or language versions directly](https://github.com/travis-ci/travis-ci/issues/4090).

So if somebody knowns of a better way please tell me, but this one works.

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>